### PR TITLE
Various fixes for compilation on linux with GCC/Clang.

### DIFF
--- a/include/andres/graph/bfs.hxx
+++ b/include/andres/graph/bfs.hxx
@@ -28,7 +28,7 @@ public:
     BreadthFirstSearchData(const GRAPH& graph)
         :   depth_(graph.numberOfVertices(), NOT_VISITED)
         {}
-    size_type add(const size_type v, const size_type depth)
+    void add(const size_type v, const size_type depth)
         { depth_[v] = depth; queue_.push(v); }
     void clearQueue()
         { queue_ = std::queue<size_type>(); }
@@ -161,13 +161,13 @@ breadthFirstSearch(
                 bool add;
 
                 callback(*it, depth, proceed, add);
-                
+
                 if(!proceed)
                 {
                     data.clearQueue();
                     return;
                 }
-                
+
                 if(add)
                     data.add(*it, depth);
             }

--- a/include/andres/graph/dfs.hxx
+++ b/include/andres/graph/dfs.hxx
@@ -25,7 +25,7 @@ public:
     DepthFirstSearchData(const GRAPH& graph)
         :   visited_(graph.numberOfVertices())
         {}
-    size_type add(const size_type v)
+    void add(const size_type v)
         { stack_.push(v); }
     void clearStack()
         { stack_ = std::stack<size_type>(); }
@@ -140,18 +140,18 @@ depthFirstSearch(
         if (!data.visited(v))
         {
             data.visited(v) = 1;
-            
+
             bool proceed;
             bool addNeighbors;
 
             callback(v, proceed, addNeighbors);
-            
+
             if (!proceed)
             {
                 data.clearStack();
                 return;
             }
-            
+
             if (addNeighbors)
             {
                 auto e_it = g.edgesFromVertexBegin(v);

--- a/include/andres/graph/grid-graph.hxx
+++ b/include/andres/graph/grid-graph.hxx
@@ -9,6 +9,7 @@
 #include <iterator>
 #include <array>
 #include <initializer_list>
+#include <type_traits>
 
 #include "adjacency.hxx"
 #include "visitor.hxx"
@@ -53,7 +54,7 @@ public:
                 std::random_access_iterator_tag,
                 const AdjacencyType
             >  {
-    public:        
+    public:
         typedef GridGraph<DIMENSION, Visitor> GraphType;
         typedef std::iterator <
                 std::random_access_iterator_tag,
@@ -191,9 +192,9 @@ public:
     size_type shape(const size_type) const;
 
     size_type vertex(const VertexCoordinate&) const;
-    void vertex(const size_type, VertexCoordinate&) const;
+    void vertex(size_type, VertexCoordinate&) const;
     size_type edge(const EdgeCoordinate&) const;
-    void edge(const size_type, EdgeCoordinate&) const;
+    void edge(size_type, EdgeCoordinate&) const;
 
 private:
     size_type vertexFromVertex(const VertexCoordinate&, const size_type, size_type&, bool&) const;
@@ -1408,5 +1409,3 @@ GridGraph<D, VISITOR>::EdgeIterator::operator[](
 } // namespace andres
 
 #endif // #ifndef ANDRES_GRAPH_GRID_GRAPH_HXX
-
-

--- a/include/andres/graph/grid-graph.hxx
+++ b/include/andres/graph/grid-graph.hxx
@@ -9,7 +9,6 @@
 #include <iterator>
 #include <array>
 #include <initializer_list>
-#include <type_traits>
 
 #include "adjacency.hxx"
 #include "visitor.hxx"

--- a/include/andres/graph/hdf5/complete-graph.hxx
+++ b/include/andres/graph/hdf5/complete-graph.hxx
@@ -12,7 +12,6 @@ namespace andres {
 namespace graph {
 namespace hdf5 {
 
-template<>
 template<class VISITOR>
 struct GraphTraitsHDF5<CompleteGraph<VISITOR> > {
     static const int ID;

--- a/include/andres/graph/hdf5/digraph.hxx
+++ b/include/andres/graph/hdf5/digraph.hxx
@@ -13,7 +13,6 @@ namespace andres {
 namespace graph {
 namespace hdf5 {
 
-template<>
 template<class VISITOR>
 struct GraphTraitsHDF5<Digraph<VISITOR> > {
     static const int ID;
@@ -36,7 +35,7 @@ save(
 ) {
     HandleCheck<ANDRES_GRAPH_HDF5_DEBUG> handleCheck;
     hid_t groupHandle = openGroup(parentHandle, graphName,true);
-    
+
     try {
         save(groupHandle, "graph-type-id", GraphTraitsHDF5<Digraph<VISITOR> >::ID);
         save(groupHandle, "multiple-edges-enabled", static_cast<unsigned char>(graph.multipleEdgesEnabled()));
@@ -70,9 +69,9 @@ load(
 ) {
     HandleCheck<ANDRES_GRAPH_HDF5_DEBUG> handleCheck;
     hid_t groupHandle = openGroup(parentHandle, graphName);
-    
+
     std::string sError;
-    
+
     try {
         int id = 0;
         load(groupHandle, "graph-type-id", id);

--- a/include/andres/graph/hdf5/graph.hxx
+++ b/include/andres/graph/hdf5/graph.hxx
@@ -13,7 +13,6 @@ namespace andres {
 namespace graph {
 namespace hdf5 {
 
-template<>
 template<class VISITOR>
 struct GraphTraitsHDF5<Graph<VISITOR> > {
     static const int ID;

--- a/include/andres/graph/hdf5/grid-graph.hxx
+++ b/include/andres/graph/hdf5/grid-graph.hxx
@@ -14,7 +14,6 @@ namespace andres {
 namespace graph {
 namespace hdf5 {
 
-template<>
 template<unsigned char D, class VISITOR>
 struct GraphTraitsHDF5<GridGraph<D, VISITOR> > {
     static const int ID;
@@ -65,7 +64,7 @@ load(
 ) {
     HandleCheck<ANDRES_GRAPH_HDF5_DEBUG> handleCheck;
     hid_t groupHandle = openGroup(parentHandle, graphName);
-    
+
     std::string sError;
     try {
         int id;

--- a/include/andres/graph/lifting.hxx
+++ b/include/andres/graph/lifting.hxx
@@ -32,7 +32,7 @@ lift(
 
     if(outputGraph.numberOfVertices() != 0)
         throw std::runtime_error("output graph is not empty.");
-    
+
     outputGraph.insertVertices(inputGraph.numberOfVertices());
 
     BreadthFirstSearchData<size_type> breadthFirstSearchData(inputGraph.numberOfVertices());
@@ -48,13 +48,13 @@ lift(
             {
                 proceed = true;
                 add = false;
-                
+
                 if (depth <= distanceUpperBound)
                 {
                     if (depth + 1 <= distanceUpperBound)
                     {
                         add = true;
-                        visited.push_back(w);        
+                        visited.push_back(w);
                     }
 
                     if (depth > distanceLowerBound)
@@ -74,7 +74,7 @@ lift(
         breadthFirstSearchData.depth(v) = BreadthFirstSearchData<size_type>::NOT_VISITED;
         for (auto w : visited)
             breadthFirstSearchData.depth(w) = BreadthFirstSearchData<size_type>::NOT_VISITED;
-        
+
         visited.clear();
     }
 }
@@ -124,12 +124,12 @@ lift(
                 std::size_t colN = cv[0] + offsetX;
                 if(colN > inputGraph.shape(0) - 1)
                     colN = inputGraph.shape(0) - 1;
-                
+
                 for (std::size_t x = col0; x <= colN; ++x)
                 {
                     if (metric == LiftingMetric::PathLength)
                     {
-                        const std::size_t distance = ::abs(x - cv[0]) + ::abs(yPlus - 1 - cv[1]);
+                        const std::size_t distance = std::abs(x - cv[0]) + std::abs(yPlus - 1 - cv[1]);
 
                         if (distance > distanceLowerBound)
                         {
@@ -160,7 +160,7 @@ lift(
 
             if (colN > inputGraph.shape(0) - 1)
                 colN = inputGraph.shape(0) - 1;
-            
+
             if (cv[0] > distanceLowerBound)
                 for (std::size_t x = col0; x <= cv[0] - distanceLowerBound - 1; ++x)
                 {
@@ -180,7 +180,7 @@ lift(
         {
             const std::size_t row0 = cv[1] + 1;
             std::size_t rowN = cv[1] + distanceUpperBound;
-            
+
             if (cv[1] + distanceUpperBound > inputGraph.shape(1) - 1)
                 rowN = inputGraph.shape(1) - 1;
 
@@ -190,7 +190,7 @@ lift(
                 const std::size_t offsetX = (metric == LiftingMetric::PathLength) ?
                                             distanceUpperBound - offsetY :
                                             ::floor(::sqrt(distanceUpperBoundSquared - offsetY * offsetY));
-                
+
                 const std::size_t col0 = cv[0] < offsetX ? 0 : cv[0] - offsetX;
                 std::size_t colN = cv[0] + offsetX;
 
@@ -201,8 +201,8 @@ lift(
                 {
                     if (metric == LiftingMetric::PathLength)
                     {
-                        const std::size_t distance = ::abs(x - cv[0]) + ::abs(y - cv[1]);
-                        
+                        const std::size_t distance = std::abs(x - cv[0]) + std::abs(y - cv[1]);
+
                         if (distance > distanceLowerBound)
                         {
                             const size_type w = inputGraph.vertex({{x, y}});

--- a/include/andres/graph/multicut-lifted/kernighan-lin.hxx
+++ b/include/andres/graph/multicut-lifted/kernighan-lin.hxx
@@ -110,7 +110,7 @@ void kernighanLin(
 
     // interatively update bipartition in order to minimize the total cost of the multicut
     for (std::size_t k = 0; k < settings.numberOfOuterIterations; ++k)
-    {        
+    {
         auto energy_decrease = .0;
 
         std::vector<std::unordered_set<std::size_t>> edges(numberOfComponents);
@@ -152,12 +152,12 @@ void kernighanLin(
                 continue;
 
             bool flag = true;
-            
+
             while (flag && !visitor.time_limit_exceeded())
             {
                 std::vector<std::size_t> new_set;
                 energy_decrease += twocut_lifted::kernighanLin(original_graph, lifted_graph, edgeCosts, partitions[i], new_set, twocut_buffers, twocut_settings);
-                
+
                 flag = !new_set.empty();
 
                 if (!new_set.empty())
@@ -167,9 +167,9 @@ void kernighanLin(
 
         if (energy_decrease == .0)
             break;
-        
+
         std::stack<std::size_t> S;
-        
+
         std::fill(visited.begin(), visited.end(), 0);
 
         // do connected component labeling on the original graph
@@ -211,7 +211,7 @@ void kernighanLin(
             if (twocut_buffers.referenced_by[v0] != twocut_buffers.referenced_by[v1])
                 new_energy_value += edgeCosts[i];
         }
-        
+
         // if the new true energy is higher, than the current one, revert the changes and terminate
         if (new_energy_value >= current_energy_value - settings.epsilon)
         {
@@ -225,7 +225,7 @@ void kernighanLin(
 
             break;
         }
-        
+
         // otherwise, form new partitions
         partitions.clear();
         partitions.resize(numberOfComponents);
@@ -233,7 +233,7 @@ void kernighanLin(
         for (std::size_t i = 0; i < original_graph.numberOfVertices(); ++i)
         {
             twocut_buffers.vertex_labels[i] = twocut_buffers.referenced_by[i];
-            
+
             partitions[twocut_buffers.vertex_labels[i]].push_back(i);
         }
 
@@ -316,9 +316,9 @@ void kernighanLin(
     const KernighanLinSettings settings = KernighanLinSettings())
 {
     struct Visitor {
-        constexpr bool operator()(std::vector<std::size_t>& vertex_labels)
+        constexpr bool operator()(std::vector<std::size_t>& vertex_labels) const
             { return true; }
-        constexpr bool time_limit_exceeded()
+        constexpr bool time_limit_exceeded() const
             { return false; }
     } visitor;
 

--- a/include/andres/graph/multicut/greedy-fixation.hxx
+++ b/include/andres/graph/multicut/greedy-fixation.hxx
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cmath>
 #include <cstddef>
 #include <iterator>
 #include <vector>
@@ -100,7 +101,7 @@ void greedyFixation(
 
         bool operator <(Edge const& other) const
         {
-            return fabs(w) < fabs(other.w);
+            return std::abs(w) < std::abs(other.w);
         }
     };
 
@@ -132,7 +133,7 @@ void greedyFixation(
 
         if (!original_graph_cp.edgeExists(edge.a, edge.b) || edge.edition < edge_editions[edge.a][edge.b])
             continue;
-        
+
         if (edge.w > typename EVA::value_type() && !original_graph_cp.isCutEdge(edge.a, edge.b))
         {
             auto stable_vertex = edge.a;

--- a/src/command-line-tools/fast-marching.hxx
+++ b/src/command-line-tools/fast-marching.hxx
@@ -6,7 +6,7 @@
 #include <iterator>
 #include <vector>
 #include <type_traits>
-        
+
 #include <andres/graph/grid-graph.hxx>
 
 
@@ -49,9 +49,9 @@ public:
 /// Implementation by Margret Keuper <keuper@mpi-inf.mpg.de>
 /// of the algorithm defined in:
 ///
-/// J.A. Sethian. Level Set Methods and Fast Marching Methods. In: 
-/// Evolving Interfaces in Computational Geometry, Fluid Mechanics, 
-/// Computer Vision and Materials Science. Cambridge University Press, 
+/// J.A. Sethian. Level Set Methods and Fast Marching Methods. In:
+/// Evolving Interfaces in Computational Geometry, Fluid Mechanics,
+/// Computer Vision and Materials Science. Cambridge University Press,
 /// 1999.
 ///
 /// \param inputGraph input graph.
@@ -102,7 +102,7 @@ fastMarching(
     typedef typename InputGraph::EdgeCoordinate EdgeCoordinate;
     typedef typename std::iterator_traits<TARGET_EDGE_VALUE_ITERATOR>::value_type Value;
     typedef typename detail::my_make_signed<Value>::type signedValue;
-    if(interpolationOrder < 0 || interpolationOrder > 1) {
+    if(interpolationOrder > 1) {
         throw std::runtime_error("specified interpolation order not implemented.");
     }
 
@@ -113,10 +113,10 @@ fastMarching(
     const Value infinity = std::numeric_limits<Value>::has_infinity
         ? std::numeric_limits<Value>::infinity()
         : std::numeric_limits<Value>::max();
-    
+
     // make explicit, for each vertex:
     // - if it is a neighbor of sourceVertex in the targret graph
-    // - if so, what the index of the connecting edge is (-1 if none) 
+    // - if so, what the index of the connecting edge is (-1 if none)
     // initialize isVertexFrozen is a Boolean vector with
     // - size targetGraph.numberOfVertices()
     // - isVertexFrozen[v] == 1 iff, for the edge e = (sourceVertex, v) in the target graph, targetEdgeValues[e] < infinity
@@ -124,24 +124,24 @@ fastMarching(
 
     // buffers.targetEdgeOfVertexWithSource_.resize(targetGraph.numberOfVertices());
     std::fill(
-        buffers.targetEdgeOfVertexWithSource_.begin(), 
-        buffers.targetEdgeOfVertexWithSource_.end(), 
+        buffers.targetEdgeOfVertexWithSource_.begin(),
+        buffers.targetEdgeOfVertexWithSource_.end(),
         maxEdge + 1
     );
-    
+
     size_type numberOfVerticesLeft = targetGraph.numberOfEdgesFromVertex(sourceVertex);
 
     // buffers.isVertexFrozen_.resize(targetGraph.numberOfVertices());
     std::fill(buffers.isVertexFrozen_.begin(), buffers.isVertexFrozen_.end(), 0);
-    
+
     // buffers.distances_.resize(targetGraph.numberOfVertices());
     std::fill(buffers.distances_.begin(), buffers.distances_.end(), infinity);
-    
+
     buffers.distances_[sourceVertex] = 0;
- 
+
     for (auto it = targetGraph.adjacenciesFromVertexBegin(sourceVertex); it != targetGraph.adjacenciesFromVertexEnd(sourceVertex); ++it)
         buffers.targetEdgeOfVertexWithSource_[it->vertex()] = it->edge();
-    
+
     struct elem
     {
         size_type v;
@@ -171,7 +171,7 @@ fastMarching(
 
         auto frozenVertex = trial.top().v;
         auto minArrivalTime = trial.top().minArrivalTime;
-        
+
         trial.pop();
 
         buffers.isVertexFrozen_[frozenVertex] = 1;
@@ -185,11 +185,11 @@ fastMarching(
             }
 
             --numberOfVerticesLeft;
-            
+
             if (numberOfVerticesLeft == 0)
                 return; // all target edge values of interest computed (exactly)
         }
-        
+
         // For each neighbor u of frozenVertex do unless isFrozen[u]
         // 1. Calculate arrival-time
         // 2. Insert u into trial set or update arrival time of u if already in the trial set.
@@ -205,20 +205,20 @@ fastMarching(
                 // Compute Arrival time
                 std::array<Value, 2> d;
                 std::array<Value, 2> T = {{infinity,infinity}};
-                
+
                 EdgeCoordinate veCoord;
                 for (size_type au_id = 0; au_id < inputGraph.numberOfEdgesFromVertex(u); ++au_id)
                 {
                     const Adjacency& au = inputGraph.adjacencyFromVertex(u, au_id);
                     const size_type v = au.vertex();
                     const size_type ve = au.edge();
-                    
+
                     inputGraph.edge(ve, veCoord);
 
                     const size_type dimension = veCoord.dimension_; // Dimension along which the edge runs (0=horiz)
                     const Value edgeWeight = inputEdgeValues[ve];
                     const Value vDistance = buffers.distances_[v];
-                    
+
                     if (vDistance == infinity)
                         continue; // Otherwise addition overflows
 
@@ -235,14 +235,14 @@ fastMarching(
                 if (T[0] < infinity)
                     if (T[1] < infinity)
                         at = std::min(T[1] + d[1], T[0] + d[0]);
-                    else 
+                    else
                         at = T[0] + d[0];
                 else
-                    if (T[1] < infinity) 
+                    if (T[1] < infinity)
                         at = T[1] + d[1];
                     else
                         at = T[1];//set to infinity in this case
-        
+
                 if (interpolationOrder == 1)
                 {
                     const Value inverseSpeed = 1;  // unexposed algorithm parameter. if large causality is violated.
@@ -254,7 +254,7 @@ fastMarching(
                         const signedValue summand = (dy2*T[0] + dx2*T[1])/denom;
                         const signedValue nom = inverseSpeed*dx2*dy2 - dy2*T[0]*T[0] - dx2*T[1]*T[1];
                         const signedValue squared = nom/denom + summand*summand;
-                        
+
                         if(squared >= 0)
                             at = std::min(at, static_cast<Value>(summand + std::sqrt(squared)));
                     }

--- a/src/command-line-tools/solve-lmp.hxx
+++ b/src/command-line-tools/solve-lmp.hxx
@@ -1,3 +1,4 @@
+#include <numeric>
 #include <stdexcept>
 #include <iostream>
 
@@ -75,7 +76,7 @@ try
 
     if (!argOptimizationMethod.isSet())
         throw std::runtime_error("No optimization method specified");
-    
+
     if (argOptimizationMethod.getValue() == "GAEC")
         parameters.optimizationMethod = Method::GAEC;
     else if (argOptimizationMethod.getValue() == "zeros")
@@ -101,7 +102,7 @@ try
         {
             if(argInitializationMethod.isSet())
                 throw std::runtime_error("Either initialization method or initial labeling must be specified.");
-            
+
             parameters.labelingHDF5FileName = argLabelingHDF5FileName.getValue();
             parameters.initialization = Initialization::Input_Labeling;
         }
@@ -139,7 +140,7 @@ void solveLiftedMulticutProblem(
     {
         auto fileHandle = andres::graph::hdf5::openFile(parameters.inputHDF5FileName);
 
-        andres::graph::hdf5::load(fileHandle, "graph", original_graph);        
+        andres::graph::hdf5::load(fileHandle, "graph", original_graph);
         andres::graph::hdf5::load(fileHandle, "graph-lifted", lifted_graph);
 
         std::vector<size_t> shape;
@@ -161,7 +162,7 @@ void solveLiftedMulticutProblem(
 
     // Solve Lifted Multicut problem
     std::vector<char> edge_labels(lifted_graph.numberOfEdges());
-    
+
     Timer t;
     t.start();
 
@@ -208,12 +209,12 @@ void solveLiftedMulticutProblem(
 
         t.stop();
 
-        auto energy_value = inner_product(edge_values.begin(), edge_values.end(), values.begin(), .0);
+        auto energy_value = std::inner_product(edge_values.begin(), edge_values.end(), values.begin(), .0);
 
         if (!parameters.outputHDF5FileName.empty())
         {
             auto file = andres::graph::hdf5::createFile(parameters.outputHDF5FileName);
-            
+
             andres::graph::hdf5::save(file, "graph", original_graph);
             andres::graph::hdf5::save(file, "energy-value", energy_value);
             andres::graph::hdf5::save(file, "running-time", t.get_elapsed_seconds());
@@ -231,13 +232,13 @@ void solveLiftedMulticutProblem(
 #endif
     else
         throw std::runtime_error("Unsupported algorithm");
-    
+
     t.stop();
-    
+
     stream << "saving decomposition into file: " << parameters.outputHDF5FileName << std::endl;
     {
         auto file = andres::graph::hdf5::createFile(parameters.outputHDF5FileName);
-        
+
         andres::graph::hdf5::save(file, "graph", original_graph);
 
         std::vector<size_t> vertex_labels(lifted_graph.numberOfVertices());
@@ -245,7 +246,7 @@ void solveLiftedMulticutProblem(
 
         andres::graph::hdf5::save(file, "labels", { vertex_labels.size() }, vertex_labels.data());
 
-        auto energy_value = inner_product(edge_values.begin(), edge_values.end(), edge_labels.begin(), .0);
+        auto energy_value = std::inner_product(edge_values.begin(), edge_values.end(), edge_labels.begin(), .0);
 
         andres::graph::hdf5::save(file, "energy-value", energy_value);
         andres::graph::hdf5::save(file, "running-time", t.get_elapsed_seconds());
@@ -253,7 +254,7 @@ void solveLiftedMulticutProblem(
         std::vector<char> true_edge_labels(lifted_graph.numberOfEdges());
         vertexToEdgeLabels(original_graph, lifted_graph, vertex_labels, true_edge_labels);
 
-        auto true_energy_value = inner_product(edge_values.begin(), edge_values.end(), true_edge_labels.begin(), .0);        
+        auto true_energy_value = std::inner_product(edge_values.begin(), edge_values.end(), true_edge_labels.begin(), .0);
 
         andres::graph::hdf5::save(file, "true-energy-value", true_energy_value);
 


### PR DESCRIPTION
@bjoern-andres I have run into some problems while compiling graph on arch linux with the latest GCC/clang compilers. This patch addresses the following issues:

* functions in ``bfs.hxx``/``dfs.hxx`` declared returning ``size_type`` but not returning anything (return type is ``void`` now),
* function parameters declared as ``const`` copies being modified in the body of the function (``const`` removed),
* superfluous ``template <>`` specifications in some HDF5-related headers (removed),
* use of ``std::abs()`` instead of ``fabs()`` and ``::abs()``,
* a small constexpr change suggested by clang for C++14 compatibility,
* ``inner_product`` -> ``std::inner_product``.

My editor introduced some noise in the patch, hopefully it's not a problem.