### PR TITLE
Fix build on MacOS.

### DIFF
--- a/include/andres/graph/lifting.hxx
+++ b/include/andres/graph/lifting.hxx
@@ -203,7 +203,8 @@ lift(
                 {
                     if (metric == LiftingMetric::PathLength)
                     {
-                        const std::size_t distance = std::abs(x - cv[0]) + std::abs(y - cv[1]);
+                        const std::size_t distance = std::abs(static_cast<long>(x - cv[0]))
+                            + std::abs(static_cast<long>(y - cv[1]));
 
                         if (distance > distanceLowerBound)
                         {


### PR DESCRIPTION
This change fixes compilation on my MacOS machine with Apple LLVM version 9.0.0 (clang-900.0.38).

```
lifting.hxx:206:54: error: call to 'abs' is ambiguous
                        const std::size_t distance = std::abs(x - cv[0]) + std::abs(y - cv[1]);
```